### PR TITLE
Replace `Carbon` types with `CarbonInterface` to support `CarbonImmutable`

### DIFF
--- a/src/Commands/HandleMessageReceived.php
+++ b/src/Commands/HandleMessageReceived.php
@@ -2,10 +2,9 @@
 
 namespace DirectoryTree\ImapEngine\Laravel\Commands;
 
-use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
 use DirectoryTree\ImapEngine\Laravel\Events\MessageReceived;
 use DirectoryTree\ImapEngine\MessageInterface;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Event;
 
@@ -17,7 +16,7 @@ class HandleMessageReceived
     public function __construct(
         protected WatchMailbox $command,
         protected int &$attempts = 0,
-        protected null|Carbon|CarbonImmutable &$lastReceivedAt = null,
+        protected ?CarbonInterface &$lastReceivedAt = null,
     ) {}
 
     /**

--- a/src/Commands/HandleMessageReceived.php
+++ b/src/Commands/HandleMessageReceived.php
@@ -2,6 +2,7 @@
 
 namespace DirectoryTree\ImapEngine\Laravel\Commands;
 
+use Carbon\CarbonImmutable;
 use DirectoryTree\ImapEngine\Laravel\Events\MessageReceived;
 use DirectoryTree\ImapEngine\MessageInterface;
 use Illuminate\Support\Carbon;
@@ -16,7 +17,7 @@ class HandleMessageReceived
     public function __construct(
         protected WatchMailbox $command,
         protected int &$attempts = 0,
-        protected ?Carbon &$lastReceivedAt = null,
+        protected null|Carbon|CarbonImmutable &$lastReceivedAt = null,
     ) {}
 
     /**

--- a/src/Events/MailboxWatchAttemptsExceeded.php
+++ b/src/Events/MailboxWatchAttemptsExceeded.php
@@ -2,8 +2,7 @@
 
 namespace DirectoryTree\ImapEngine\Laravel\Events;
 
-use Carbon\Carbon;
-use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
 use Exception;
 
 class MailboxWatchAttemptsExceeded
@@ -15,6 +14,6 @@ class MailboxWatchAttemptsExceeded
         public string $mailbox,
         public int $attempts,
         public Exception $exception,
-        public null|Carbon|CarbonImmutable $lastReceivedAt = null,
+        public ?CarbonInterface $lastReceivedAt = null,
     ) {}
 }

--- a/src/Events/MailboxWatchAttemptsExceeded.php
+++ b/src/Events/MailboxWatchAttemptsExceeded.php
@@ -3,6 +3,7 @@
 namespace DirectoryTree\ImapEngine\Laravel\Events;
 
 use Carbon\Carbon;
+use Carbon\CarbonImmutable;
 use Exception;
 
 class MailboxWatchAttemptsExceeded
@@ -14,6 +15,6 @@ class MailboxWatchAttemptsExceeded
         public string $mailbox,
         public int $attempts,
         public Exception $exception,
-        public ?Carbon $lastReceivedAt = null,
+        public null|Carbon|CarbonImmutable $lastReceivedAt = null,
     ) {}
 }


### PR DESCRIPTION
Some of the laravel projects prefer to work with Immutable Dates.

```php
Date::use(CarbonImmutable::class);
```

and using this package while keeping this approach results in the follwoing error

```bash
 php artisan imap:watch default --with=flags,headers,body
Watching mailbox [default]...
Message received: [7]

   TypeError 

  Cannot assign Carbon\CarbonImmutable to property DirectoryTree\ImapEngine\Laravel\Commands\HandleMessageReceived::$lastReceivedAt of type ?Illuminate\Support\Carbon

  at vendor/directorytree/imapengine-laravel/src/Commands/HandleMessageReceived.php:33
     29▕         );
     30▕ 
     31▕         $this->attempts = 0;
     32▕ 
  ➜  33▕         $this->lastReceivedAt = Date::now();
     34▕ 
     35▕         Event::dispatch(new MessageReceived($message));
     36▕     }
     37▕ }

      +20 vendor frames 

  21  artisan:13
      Illuminate\Foundation\Application::handleCommand()
```