### PR TITLE
Add `method` option to `imap:watch` command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "directorytree/imapengine": "^1.13.0",
+        "directorytree/imapengine": "^1.19.0",
         "illuminate/contracts": "^10.0|^11.0|^12.0"
     },
     "require-dev": {

--- a/src/Commands/WatchMailbox.php
+++ b/src/Commands/WatchMailbox.php
@@ -12,6 +12,7 @@ use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
+use Symfony\Component\Console\Exception\InvalidOptionException;
 
 class WatchMailbox extends Command
 {
@@ -58,6 +59,9 @@ class WatchMailbox extends Command
                         new HandleMessageReceived($this, $attempts, $lastReceivedAt),
                         new ConfigureIdleQuery($with),
                         $this->option('timeout'),
+                    ),
+                    default => throw new InvalidOptionException(
+                        "Invalid method [{$this->option('method')}]. Valid options are [idle, poll]."
                     ),
                 };
             } catch (Exception $e) {

--- a/src/Commands/WatchMailbox.php
+++ b/src/Commands/WatchMailbox.php
@@ -7,7 +7,6 @@ use DirectoryTree\ImapEngine\Laravel\Events\MailboxWatchAttemptsExceeded;
 use DirectoryTree\ImapEngine\Laravel\Facades\Imap;
 use DirectoryTree\ImapEngine\Laravel\Support\LoopInterface;
 use DirectoryTree\ImapEngine\MailboxInterface;
-use DirectoryTree\ImapEngine\Message;
 use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Event;
@@ -35,6 +34,10 @@ class WatchMailbox extends Command
      */
     public function handle(LoopInterface $loop): void
     {
+        if (! in_array($method = $this->option('method'), ['idle', 'poll'])) {
+            throw new InvalidOptionException("Invalid method [{$method}]. Valid options are [idle, poll].");
+        }
+
         $mailbox = Imap::mailbox($name = $this->argument('mailbox'));
 
         $with = explode(',', $this->option('with'));
@@ -59,9 +62,6 @@ class WatchMailbox extends Command
                         new HandleMessageReceived($this, $attempts, $lastReceivedAt),
                         new ConfigureIdleQuery($with),
                         $this->option('timeout'),
-                    ),
-                    default => throw new InvalidOptionException(
-                        "Invalid method [{$this->option('method')}]. Valid options are [idle, poll]."
                     ),
                 };
             } catch (Exception $e) {


### PR DESCRIPTION
This PR adds the `--method` option to the `imap:watch` command to allow developers to use the [long-polling feature](https://imapengine.com/docs/usage/monitoring#using-long-polling) of the core ImapEngine package on a mailbox folder, instead of solely `idle`.